### PR TITLE
Fix bad super() calls in abstract models def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/steps/classes.py
+++ b/steps/classes.py
@@ -110,7 +110,7 @@ class ClassModel(abstract_model.DictModel):
         self.is_runnable = False
         self.bdModel = bdModel
         itemClass = getattr(sys.modules[__name__], ClassItem.__name__)
-        super().__init__(self,itemClass,feedback=bdModel.feedback)
+        super().__init__(itemClass, feedback=bdModel.feedback)
         
     def mkItemFromDict(self,dict):
         utils.checkFields(self.fields,dict.keys())

--- a/steps/cost.py
+++ b/steps/cost.py
@@ -66,7 +66,7 @@ class CostModel(abstract_model.DictModel):
         self.is_runnable = True
         self.bdModel = bdModel
         itemClass = getattr(sys.modules[__name__], CostItem.__name__)
-        super().__init__(self,itemClass,feedback=bdModel.feedback)
+        super().__init__(itemClass, feedback=bdModel.feedback)
     
     def mkItemFromDict(self,dict):
         utils.checkFields(cost_fields,dict.keys())

--- a/steps/groups.py
+++ b/steps/groups.py
@@ -148,7 +148,7 @@ class GroupModel(abstract_model.DictModel):
         self.is_runnable = False
         self.bdModel = bdModel
         itemClass = getattr(sys.modules[__name__], GroupItem.__name__)
-        super().__init__(self,itemClass,feedback=bdModel.feedback)
+        super().__init__(itemClass, feedback=bdModel.feedback)
         
     def mkItemFromDict(self,dict):
         utils.checkFields(groups_fields,dict.keys())

--- a/steps/selection.py
+++ b/steps/selection.py
@@ -94,7 +94,7 @@ class SelectionModel(abstract_model.DictModel):
         self.is_runnable = True
         self.bdModel = bdModel
         itemClass = getattr(sys.modules[__name__], SelectionItem.__name__)
-        super().__init__(self,itemClass,feedback=bdModel.feedback)
+        super().__init__(itemClass, feedback=bdModel.feedback)
         
     def mkItemFromDict(self,dict):
         utils.checkFields(selection_fields,dict.keys())

--- a/steps/subnetworks.py
+++ b/steps/subnetworks.py
@@ -41,10 +41,10 @@ class STItem(abstract_model.DictItem):
 
     @classmethod
     def fromValues(cls,st,descr):
-        dict = {cls.NAME : st,
+        dct = {cls.NAME : st,
                 cls.DESCR : descr}
         #assert(st_fields == dict.keys())
-        st_item = cls(dict)
+        st_item = cls(dct)
         return st_item
         
     def checkItem(self):
@@ -95,7 +95,7 @@ class STModel(abstract_model.DictModel):
         self.is_runnable = False
         self.bdModel = bdModel
         itemClass = getattr(sys.modules[__name__], STItem.__name__)
-        super().__init__(self,itemClass,feedback=bdModel.feedback)
+        super().__init__(itemClass, feedback=bdModel.feedback)
         
     def getSTByName(self,st_name):
         for st in self.items:


### PR DESCRIPTION
This should fix #24 and also I added the gitignore to avoid manually ignoring the content of `__pycache__` .

Also, I slightly modified qgis_lib_mc accordingly to make sure this is working right (by the way I removed the default "fields" arg, you should avoid empty list as default arguments since this can produce undesired side effects (on list objects shared by every class instances !)